### PR TITLE
initial strudel implementation

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/agl/ed25519"
+)
+
+type (
+	Sig     [ed25519.SignatureSize]byte
+	PubKey  [ed25519.PublicKeySize]byte
+	PubKeys []PubKey // implements flag.Value
+)
+
+// DecodeKey returns a PubKey from its base64 representation
+func DecodeKey(s string) (PubKey, error) {
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return PubKey{}, err
+	}
+	if len(data) != ed25519.PublicKeySize {
+		return PubKey{}, fmt.Errorf("keys are 32 bytes ed25519 public keys, recieved: %v", len(data))
+	}
+
+	// slice -> array
+	var key PubKey
+	copy(key[:], data)
+
+	return key, nil
+}
+
+// DecodeSig returns a Sig from its base64 representation
+func DecodeSig(s string) (Sig, error) {
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return Sig{}, err
+	}
+	if len(data) != ed25519.SignatureSize {
+		return Sig{}, fmt.Errorf("keys are 32 bytes ed25519 public keys, recieved: %v", len(data))
+	}
+
+	// slice -> array
+	var key Sig
+	copy(key[:], data)
+
+	return key, nil
+}
+
+func (key PubKey) Verify(msg []byte, sig Sig) bool {
+	var (
+		k [ed25519.PublicKeySize]byte = key
+		s [ed25519.SignatureSize]byte = sig
+	)
+	return ed25519.Verify(&k, msg, &s)
+}
+
+func (keys PubKeys) String() string {
+	var out []string
+	for _, key := range keys {
+		s := base64.StdEncoding.EncodeToString(key[:])
+		out = append(out, s)
+	}
+	return fmt.Sprintf("%v", out)
+}
+
+// Set will append additional keys for each flag set. Comma separated flags
+// without spaces will also be parsed correctly.
+func (keys *PubKeys) Set(value string) error {
+	values := strings.Split(value, ",")
+
+	for _, s := range values {
+		key, err := DecodeKey(s)
+		if err != nil {
+			return err
+		}
+		*keys = append(*keys, key)
+	}
+
+	return nil
+}

--- a/cmd/strudel.go
+++ b/cmd/strudel.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/coreos/strudel/config"
+	"github.com/coreos/strudel/strudel"
+)
+
+const (
+	cliName        = "strudel"
+	cliDescription = "strudel, upgrade rkt pods with omaha"
+)
+
+var (
+	globalFlagset = flag.NewFlagSet(cliName, flag.ExitOnError)
+)
+
+func main() {
+	var cfg config.AppConfig
+
+	fs := flag.NewFlagSet(cliName, flag.ExitOnError)
+	fs.StringVar(&cfg.ServiceName, "service-name", "", "systemd service file name to locally identify app")
+	fs.StringVar(&cfg.AppID, "app-id", "", "app UUID on omaha server (not pod UUID)")
+	fs.StringVar(&cfg.Endpoint, "endpoint", "", "omaha server URL")
+	fs.StringVar(&cfg.Group, "group", "", " omaha user configured tags, e.g. 'alpha'")
+	fs.StringVar(&cfg.UnitDir, "unit-dir", "/run/systemd/system", "systemd unit path for writing payloads")
+	fs.StringVar(&cfg.UpdateMethod, "update-method", "restart", "'restart' is the only valid method for now")
+	fs.BoolVar(&cfg.InsecureSkipVerify, "insecure-skip-verify", false, "skip signature verification of payload")
+	fs.Var(&cfg.PubKeys, "keys", "base64 encoded ed25519 public key, multiple flags will specify multiple keys ")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		log.Fatalf("flag parsing failed: %v", err)
+	}
+	if fs.NArg() != 0 {
+		log.Fatalf("unknown arguments: %v", fs.Args())
+	}
+
+	getFlagsFromEnv(cliName, fs)
+
+	if err := cfg.Valid(); err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	err := strudel.RunTryUpdate(cfg)
+	if err != nil {
+		log.Fatalf("failed to update: %v", err)
+	}
+
+	return
+}
+
+// getFlagsFromEnv parses all registered flags in the given flagset,
+// and if they are not already set it attempts to set their values from
+// environment variables. Environment variables take the name of the flag but
+// are UPPERCASE, have the given prefix, and any dashes are replaced by
+// underscores - for example: some-flag => PREFIX_SOME_FLAG
+func getFlagsFromEnv(prefix string, fs *flag.FlagSet) {
+	alreadySet := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) {
+		alreadySet[f.Name] = true
+	})
+	fs.VisitAll(func(f *flag.Flag) {
+		if !alreadySet[f.Name] {
+			key := strings.ToUpper(prefix + "_" + strings.Replace(f.Name, "-", "_", -1))
+			val := os.Getenv(key)
+			if val != "" {
+				fs.Set(f.Name, val)
+			}
+		}
+
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/strudel/auth"
+)
+
+const serviceExt = ".service.conf"
+
+type AppConfig struct {
+	ServiceName        string
+	AppID              string
+	Endpoint           string
+	Group              string
+	UnitDir            string
+	UpdateMethod       string
+	InsecureSkipVerify bool
+	PubKeys            auth.PubKeys
+
+	localVersion string //sha256 hash of service file
+}
+
+func (c *AppConfig) Valid() error {
+	if c.ServiceName == "" {
+		return fmt.Errorf("service name not set")
+	}
+	if c.AppID == "" {
+		return fmt.Errorf("app ID not set")
+	}
+	if c.Endpoint == "" {
+		return fmt.Errorf("omaha endpoint not set")
+	}
+	if c.Group == "" {
+		return fmt.Errorf("group not set")
+	}
+	if c.UnitDir == "" {
+		return fmt.Errorf("unit-dir not set")
+	}
+	if len(c.PubKeys) == 0 && c.InsecureSkipVerify == false {
+		return fmt.Errorf("no public keys specified while insecure-skip-verify is false")
+	}
+	if len(c.PubKeys) > 0 && c.InsecureSkipVerify == true {
+		return fmt.Errorf("pubic keys specified while insecure-skip-verify is set")
+	}
+	return nil
+}
+
+func (cfg *AppConfig) OmahaEndpoint() string {
+	return fmt.Sprintf("%s/v1/update/", cfg.Endpoint)
+}
+
+// GetLocalVersion gets the version hash of the service file. If the file
+// doesn't exist, an empty string will be returned.
+// TODO: add semantic versioning support
+func (cfg *AppConfig) GetLocalVersion() (string, error) {
+	// TODO: Open Question: should the user be warned about updating a pod for
+	// which other service files exist? If there was a RO service file it could
+	// conflict with future upgrades to the given service file.
+
+	// locate expected service file
+	filebytes, err := ioutil.ReadFile(cfg.GetPath())
+	if err == os.ErrNotExist {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading service file: %v", err)
+	}
+
+	cfg.localVersion = getVersionHash(filebytes)
+	return cfg.localVersion, nil
+}
+
+func (cfg *AppConfig) GetPath() string {
+	return filepath.Join(cfg.UnitDir, cfg.ServiceName+serviceExt)
+}
+
+func getVersionHash(filebytes []byte) string {
+	hasher := sha256.New()
+	hasher.Write(filebytes)
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+}

--- a/strudel/payload.go
+++ b/strudel/payload.go
@@ -1,0 +1,128 @@
+package strudel
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/coreos/strudel/auth"
+)
+
+// Omaha payload is json and signed using the camlistore spec:
+// https://github.com/camlistore/camlistore/tree/master/doc/json-signing/example
+type Payload struct {
+	ServiceFile string `json:"servicefile"` // base64 encoded service file
+	Signer      string `json:"signer"`      // base64 ed25519 pubkey
+	Sig         string `json:"sig"`         // base64 ed25519 sig
+
+	signedBytes []byte `json:"-"` // actual signed data
+}
+
+// NewPayload takes the byte payload of an omaha update and parses it according
+// to the camlistore json-signing spec. It does not verify the signature.
+func NewPayload(jsonbytes []byte) (*Payload, error) {
+	const sep = `,"sig":"`
+
+	//bytes all
+	ba := jsonbytes
+
+	// find last index in b of the 8 byte substring: `,"sig":"`
+	idx := bytes.LastIndex(ba, []byte(sep))
+	if idx == -1 {
+		return nil, fmt.Errorf("no 8 byte separator found in json")
+	}
+
+	// TODO: rewrite camli sig spec to embody our name changes(e.g. camliSig ->
+	// sig) and change these ba,bp,bpj names to something less confusing. For
+	// now, the names might as well make sense while reading  camlistore spec.
+
+	// bytes payload
+	bp := ba[:idx]
+
+	// bytes payload json
+	bpj := ba[:idx+1]
+	bpj[idx] = '}'
+
+	// bytes sig. Must allocate new underlying memory for sig because otherwise
+	// the "}" set in bs will overwrite the "{" we would set in bpj.
+	bs := []byte("{")
+	bs = append(bs, ba[idx+1:]...)
+
+	// parse bpj as a Payload
+	var p Payload
+	if err := json.Unmarshal(bpj, &p); err != nil {
+		return nil, fmt.Errorf("invalid JSON in payload: %v", err)
+	}
+	if p.Signer == "" {
+		return nil, fmt.Errorf("empty or missing 'signer' field in JSON payload")
+	}
+
+	// parse bs as JSON and ensure that only the key "sig" exists
+	var sigMap map[string]interface{}
+	if err := json.Unmarshal(bs, &sigMap); err != nil {
+		return nil, fmt.Errorf("invalid JSON in signature: %v", err)
+	}
+
+	if len(sigMap) != 1 {
+		return nil, fmt.Errorf("JSON signature must have 1 key")
+	}
+
+	sig, ok := sigMap["sig"]
+	if !ok {
+		return nil, fmt.Errorf("missing 'sig' in JSON signature")
+	}
+
+	p.Sig, ok = sig.(string)
+	if !ok {
+		return nil, fmt.Errorf("'sig' is not a string")
+	}
+
+	p.signedBytes = bp
+	return &p, nil
+
+}
+
+// VerifySig matches the Payload.Signer field with one of the provided trusted public
+// keys and cryptographically verifies the payload signature using that public
+// key.
+func (p *Payload) VerifySig(keys auth.PubKeys) bool {
+	signer, err := auth.DecodeKey(p.Signer)
+	if err != nil {
+		log.Print(err)
+		return false
+	}
+	sig, err := auth.DecodeSig(p.Sig)
+	if err != nil {
+		log.Print(err)
+		return false
+	}
+
+	// verify signer is a trusted key
+	var signerTrusted bool
+	for _, key := range keys {
+		if key == signer {
+			signerTrusted = true
+			break
+		}
+	}
+	if !signerTrusted {
+		return false
+	}
+
+	return signer.Verify(p.signedBytes, sig)
+
+}
+
+// overwrite or create new service file
+func (p *Payload) OverwriteServiceFile(path string) error {
+	b, err := base64.StdEncoding.DecodeString(p.ServiceFile)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b, os.FileMode(0644))
+}

--- a/strudel/payload_test.go
+++ b/strudel/payload_test.go
@@ -1,0 +1,79 @@
+package strudel
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+	"unicode"
+
+	"github.com/agl/ed25519"
+	"github.com/coreos/strudel/auth"
+)
+
+type zeroReader struct{}
+
+func (zeroReader) Read(buf []byte) (int, error) {
+	for i := range buf {
+		buf[i] = 0
+	}
+	return len(buf), nil
+}
+
+var (
+	zero               zeroReader
+	public, private, _ = ed25519.GenerateKey(zero)
+	pubString          = base64.StdEncoding.EncodeToString(public[:])
+	badSigner          = base64.StdEncoding.EncodeToString(make([]byte, ed25519.PublicKeySize))
+)
+
+func TestPayloadVerify(t *testing.T) {
+	var payloadTests = []struct {
+		input         []byte // JSON with servicefile and signer fields, sig is added automatically
+		expectSuccess bool
+	}{
+		{[]byte(`{"servicefile":"test", "signer":""}`), false},                  // empty signer
+		{[]byte(`{"servicefile":"test", "signer":"` + badSigner + `"}`), false}, // signer doesn't match added sig
+		{[]byte(`{"servicefile":"", "signer":"` + pubString + `"}`), true},      // empty service file
+		{[]byte(`{"signer":"` + pubString + `"}`), true},                        // service file missing
+		{[]byte(`{"servicefile":"test", "signer":"` + pubString + `"}`), true},
+		{[]byte(`{"servicefile":"test","foo":"bar","signer":"` + pubString + `"}`), true}, // exta fields ok as long as sig is last
+	}
+	for _, tt := range payloadTests {
+		// add signature
+		input := addSig(tt.input)
+
+		// parse input
+		p, err := NewPayload(input)
+		if err != nil {
+			if tt.expectSuccess == false {
+				continue
+			} else {
+				t.Fatalf("err: %v from NewPayload using test input: %s", err, input)
+			}
+		}
+		// verify input using signer
+		givenSigner, _ := auth.DecodeKey(p.Signer)
+		actual := p.VerifySig(auth.PubKeys{givenSigner})
+		if actual != tt.expectSuccess {
+			t.Fatalf("expected %v from VerifySig using test input: %s", tt.expectSuccess, input)
+		}
+	}
+
+}
+
+func addSig(b []byte) []byte {
+
+	// remove trailing whitespace
+	b = bytes.TrimRightFunc(b, unicode.IsSpace)
+	// and last '}'
+	b = b[:len(b)-1]
+
+	sig := ed25519.Sign(private, b)
+	sigString := base64.StdEncoding.EncodeToString(sig[:])
+
+	// append signature
+	suffix := []byte(`,"sig":"` + sigString + `"}` + "\n")
+	b = append(b, suffix...)
+
+	return b
+}

--- a/strudel/run.go
+++ b/strudel/run.go
@@ -1,0 +1,75 @@
+package strudel
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/coreos/strudel/config"
+	"github.com/coreos/strudel/update"
+)
+
+// Run strudel with valid config from main
+func RunTryUpdate(cfg config.AppConfig) error {
+	log.Printf("updating pod: %v", cfg.ServiceName)
+
+	initialVersion, err := cfg.GetLocalVersion()
+	if err != nil {
+		return err
+	}
+
+	if initialVersion == "" {
+		log.Println("service file not found, one will be created on succesful update")
+	}
+
+	poller := update.NewPoller(initialVersion, cfg)
+	resp, err := poller.Check()
+	if err != nil {
+		return fmt.Errorf("error, upate check failed: %v", err)
+	}
+
+	if resp == nil {
+		log.Println("no update needed")
+		//TODO: signal this with error type
+		return nil
+	}
+
+	updatePayload, err := poller.Download(resp)
+	if err != nil {
+		log.Println("error: %b", err)
+		return err
+	}
+
+	// parse json payload
+	p, err := NewPayload(updatePayload.Body)
+	if err != nil {
+		return fmt.Errorf("error parsing payload: %v", err)
+	}
+
+	// verify signature
+	if p.VerifySig(cfg.PubKeys) != true || cfg.InsecureSkipVerify {
+		return fmt.Errorf("unable to verify json signature")
+	}
+
+	// TODO: Support multiple update strategies and use coreos/go-systemd. For
+	// now this is used just to test basic usage of everything.
+
+	// naive service update -- daemon-reload and then restart
+	err = p.OverwriteServiceFile(cfg.GetPath())
+	if err != nil {
+		return fmt.Errorf("overwriting service file: %v", err)
+	}
+
+	cmd := exec.Command("systemctl", "daemon-reload", cfg.ServiceName)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %v", err, b)
+	}
+	cmd = exec.Command("systemctl", "restart", cfg.ServiceName)
+	b, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v: %v", err, b)
+	}
+
+	return nil
+}

--- a/update/poller.go
+++ b/update/poller.go
@@ -1,0 +1,133 @@
+package update
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/coreos/go-omaha/omaha"
+	"github.com/coreos/strudel/config"
+)
+
+type Poller struct {
+	currentVersion string
+	appConfig      config.AppConfig
+}
+
+func NewPoller(version string, appConfig config.AppConfig) *Poller {
+	return &Poller{version, appConfig}
+}
+
+func (p *Poller) Check() (*updateCheckResponse, error) {
+	resp, err := p.sendEvent(omahaEventComplete)
+	if resp == nil || err != nil {
+		return nil, err
+	}
+
+	if resp.Status == UpdateCheckStatusNoUpdate || resp.Status == UpdateCheckStatusErrorVersion {
+		return nil, nil
+	}
+
+	if resp.Version == p.currentVersion {
+		return nil, nil
+	}
+
+	return resp, nil
+}
+
+func (p *Poller) Download(resp *updateCheckResponse) (*OmahaPayload, error) {
+	p.sendEventAndLog(omahaEventDownloading)
+
+	body, err := fetchURL(resp.PackageURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch payload of package v%s from %s: %v", resp.Version, resp.PackageURL, err)
+	}
+
+	pl := &OmahaPayload{
+		Version: resp.Version,
+		Body:    body,
+	}
+
+	p.sendEventAndLog(omahaEventDownloaded)
+	p.sendEventAndLog(omahaEventInstalled)
+
+	return pl, nil
+}
+
+// Send an Omaha request to the update service.
+func (p *Poller) sendEvent(event omahaEvent) (*updateCheckResponse, error) {
+	client := &http.Client{}
+
+	request := omaha.NewRequest("", "", "", "")
+	app := request.AddApp(p.appConfig.AppID, p.currentVersion)
+	app.AddUpdateCheck()
+	app.Track = p.appConfig.Group
+
+	e := app.AddEvent()
+	e.Type = strconv.Itoa(event.Type)
+	e.Result = strconv.Itoa(event.Result)
+
+	raw, err := xml.MarshalIndent(request, "", " ")
+	if err != nil {
+		return nil, fmt.Errorf("failed marshaling omaha request: %v", err)
+	}
+
+	// log.Debugf("Sending omaha request: %s%s", xml.Header, raw)
+
+	resp, err := client.Post(p.appConfig.OmahaEndpoint(), "text/xml", bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("failed sending omaha event to server: %v", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal omaha response: %v", err)
+	}
+
+	// log.Debugf("omaha response: %s%s", xml.Header, string(body))
+
+	var oresp omaha.Response
+	if err = xml.Unmarshal(body, &oresp); err != nil {
+		return nil, err
+	}
+
+	return parseUpdateCheckResponse(oresp.Apps[0].UpdateCheck)
+}
+
+// Just send a status and disregard the response.
+func (p *Poller) sendEventAndLog(event omahaEvent) {
+	if _, err := p.sendEvent(event); err != nil {
+		log.Printf("Error sending %q event: %v", event.Name, err)
+	}
+}
+
+// Parse all needed data out of the update check's response.
+func parseUpdateCheckResponse(uc *omaha.UpdateCheck) (*updateCheckResponse, error) {
+	// Don't parse out package details if they dont exist.
+	if uc.Status == UpdateCheckStatusNoUpdate || uc.Status == UpdateCheckStatusErrorVersion {
+		return nil, nil
+	}
+
+	u, err := url.Parse(uc.Urls.Urls[0].CodeBase)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing url: %v", err)
+	}
+
+	name := uc.Manifest.Packages.Packages[0].Name
+	u.Path = path.Join(u.Path, name)
+
+	resp := updateCheckResponse{
+		Status:      uc.Status,
+		PackageURL:  u.String(),
+		PackageName: name,
+		Version:     uc.Manifest.Version,
+	}
+
+	return &resp, nil
+}

--- a/update/update.go
+++ b/update/update.go
@@ -1,0 +1,61 @@
+package update
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	UpdateCheckStatusErrorVersion = "error-version"
+	UpdateCheckStatusNoUpdate     = "noupdate"
+)
+
+var (
+	omahaEventDownloading = omahaEvent{Name: "downloading", Type: 13, Result: 1}
+	omahaEventDownloaded  = omahaEvent{Name: "downloaded", Type: 14, Result: 1}
+	omahaEventInstalled   = omahaEvent{Name: "installed", Type: 3, Result: 1}
+	omahaEventComplete    = omahaEvent{Name: "complete", Type: 3, Result: 2}
+	omahaEventHold        = omahaEvent{Name: "hold", Type: 800, Result: 1}
+	omahaEventError       = omahaEvent{Name: "error", Type: 3, Result: 0}
+)
+
+type omahaEvent struct {
+	Name   string
+	Type   int
+	Result int
+}
+
+// Relevant information in response from an update check.
+type updateCheckResponse struct {
+	Version     string
+	PackageURL  string
+	PackageName string
+	Status      string
+}
+
+type OmahaPayload struct {
+	Version string
+	Body    []byte
+}
+
+func fetchURL(loc string) ([]byte, error) {
+	req, err := http.NewRequest("GET", loc, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &http.Client{
+		Transport: http.DefaultTransport,
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}


### PR DESCRIPTION
This commit lands the initial implementation of the strudel updater.
Omaha code is untested and there is only a one-shot upgrade command, no
scheduling. Next planned steps are:

- creating a tool to sign and create payloads that can be used with
  updateservicectl

- manual end-to-end testing with an instance of core-update

- supporting multiple upgrade strategies more robust then the current
  naive strategy

- add a cmd that works as a long-running scheduler that will read config
  files to up

/cc @bcwaldon @marineam @aaronlevy